### PR TITLE
Fix crash in SVGAParser

### DIFF
--- a/Source/SVGAParser.m
+++ b/Source/SVGAParser.m
@@ -184,7 +184,7 @@ static NSOperationQueue *unzipQueue;
         }
         return;
     }
-    if (!data || data.length < 5) {
+    if (!data || data.length < 4) {
         return;
     }
     NSData *tag = [data subdataWithRange:NSMakeRange(0, 4)];

--- a/Source/SVGAParser.m
+++ b/Source/SVGAParser.m
@@ -184,6 +184,9 @@ static NSOperationQueue *unzipQueue;
         }
         return;
     }
+    if (!data || data.length < 5) {
+        return;
+    }
     NSData *tag = [data subdataWithRange:NSMakeRange(0, 4)];
     if (![[tag description] isEqualToString:@"<504b0304>"]) {
         // Maybe is SVGA 2.0.0


### PR DESCRIPTION
## The Crash

```
#601047 NSRangeException
*** -[_NSZeroData subdataWithRange:]: range {0, 4} exceeds data length 0
```

## Problem

In SVGAParser's method: 
``` objc
- (void)parseWithData:(nonnull NSData *)data
             cacheKey:(nonnull NSString *)cacheKey
      completionBlock:(void ( ^ _Nullable)(SVGAVideoEntity * _Nonnull videoItem))completionBlock
         failureBlock:(void ( ^ _Nullable)(NSError * _Nonnull error))failureBlock;
```
there's no length check for `data`, and `NSData *tag = [data subdataWithRange:NSMakeRange(0, 4)];` is used directly. 

This method is called in `parseWithNamed:inBundle:completionBlock:failureBlock`, though there is a check for `filePath`, the `data` may still be empty sometimes.

## Solution

I've added these code in `parseWithData:cacheKey:completionBlock:failureBlock`
```objc
    if (!data || data.length < 4) {
        return;
    }
```
