### PR TITLE
FIX : 解决player不可见时依然在持续播放

### DIFF
--- a/Source/SVGAPlayer.m
+++ b/Source/SVGAPlayer.m
@@ -301,6 +301,9 @@ static NSArray *_contentLayers;
 }
 
 - (void)next {
+    if (!self.window) {
+        return;
+    }
     if (self.reversing) {
         self.currentFrame--;
         if (self.currentFrame < (NSInteger)MAX(0, self.currentRange.location)) {


### PR DESCRIPTION
发现在个别业务代码中有同学没有及时`stopAnimation`，导致svga动画一直在播放，比较占用CPU资源。
我这边考虑可否直接在`next`方法中直接做判断，这样可以在底层库这边做个限制做兜底保障。

如下改动只会影响从一个页面跳到另一个页面的case，并没有做其他case考虑，以免影响过大。